### PR TITLE
[Conduit]: Fix 500 on article pages caused by orphan comments

### DIFF
--- a/api/articles.js
+++ b/api/articles.js
@@ -414,11 +414,17 @@ router.get(
           { model: req.app.get('sequelize').models.User, as: 'author' },
         ],
       })
+      // Skip comments whose author was deleted (orphans from the weekly
+      // cleanup script — the schema has no ON DELETE CASCADE).
       return res.json({
         comments: await Promise.all(
-          comments.map(function (comment) {
-            return comment.toJson(user)
-          })
+          comments
+            .filter(function (comment) {
+              return comment.author
+            })
+            .map(function (comment) {
+              return comment.toJson(user)
+            })
         ),
       })
     } catch (error) {

--- a/back/ArticlePage.ts
+++ b/back/ArticlePage.ts
@@ -46,8 +46,12 @@ export function getStaticPropsArticle(
     }
     const props: ArticlePageProps = { article: await article.toJson() }
     if (addComments) {
+      // Skip comments whose author was deleted. The sandbox DB has no
+      // ON DELETE CASCADE, so a deleted user leaves orphan comments behind.
       props.comments = await Promise.all(
-        comments.map((comment) => comment.toJson())
+        comments
+          .filter((comment) => comment.author)
+          .map((comment) => comment.toJson())
       )
     }
     const ret: Awaited<ReturnType<GetStaticProps>> = {

--- a/bin/db_maintenance.sh
+++ b/bin/db_maintenance.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Weekly maintenance for the conduit sandbox DB.
+#
+# Removes user-generated data accumulated by QA students, keeping only a
+# whitelist of seed users and tags. Runs from cron on the EC2 instance:
+#
+#   0 0 * * 1 /home/ec2-user/projects/conduit-node-express-sequelize-nextjs/bin/db_maintenance.sh >> /home/ec2-user/db_maintenance.log 2>&1
+#
+# Deletes happen in FK-safe order (children before parents) because the
+# schema has no ON DELETE CASCADE.
+
+set -euo pipefail
+
+: "${PGHOST:=mateacademy-database-development.cqw7zu22pde8.eu-central-1.rds.amazonaws.com}"
+: "${PGPORT:=5432}"
+: "${PGUSER:=realworld_next_user}"
+: "${PGDATABASE:=realworld_next}"
+: "${PGPASSWORD:=a}"
+export PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD
+
+KEEP_USER_IDS="134946, 455152, 455148, 455140, 455150, 455156, 455144, 455154, 455146, 455138, 455142, 541999, 541997, 542012, 541995, 542014, 542001, 541991, 542003, 541993, 542010, 823587, 823638"
+KEEP_TAG_NAMES="'welcome', '4308', 'text', 'longLongLongLong', 'oneMore', 'TestTag', 'ATB', 'newTag', 'softwareTesting', 'testingTheory', 'wilcommen', 'articleTag', 'tags'"
+
+echo "=== db_maintenance started at $(date --utc) ==="
+
+psql -v ON_ERROR_STOP=1 <<SQL
+BEGIN;
+
+-- Child tables that reference User or Article must be cleaned first,
+-- otherwise deleting Users/Articles leaves orphan rows that crash the app
+-- (e.g. Comment.toJson would null-deref on a missing author).
+
+DELETE FROM "UserFollowUser"
+ WHERE "userId"   NOT IN (${KEEP_USER_IDS})
+    OR "followId" NOT IN (${KEEP_USER_IDS});
+
+DELETE FROM "UserFavoriteArticle"
+ WHERE "userId" NOT IN (${KEEP_USER_IDS});
+
+DELETE FROM "Comment"
+ WHERE "authorId" NOT IN (${KEEP_USER_IDS});
+
+DELETE FROM "ArticleTag"
+ WHERE "articleId" IN (SELECT id FROM "Article" WHERE "authorId" NOT IN (${KEEP_USER_IDS}));
+
+DELETE FROM "Article"
+ WHERE "authorId" NOT IN (${KEEP_USER_IDS});
+
+-- Now safe to remove users.
+DELETE FROM "User"
+ WHERE id NOT IN (${KEEP_USER_IDS});
+
+-- Tag cleanup (no FK dependency).
+DELETE FROM "Tag" WHERE "name" NOT IN (${KEEP_TAG_NAMES});
+DELETE FROM "Tag" WHERE "name" IS NULL;
+
+COMMIT;
+SQL
+
+echo "=== db_maintenance finished at $(date --utc) ==="

--- a/models/comment.js
+++ b/models/comment.js
@@ -11,7 +11,9 @@ module.exports = (sequelize) => {
       body: this.body,
       createdAt: this.createdAt.toISOString(),
       updatedAt: this.updatedAt.toISOString(),
-      author: await this.author.toProfileJSONFor(user),
+      author: this.author
+        ? await this.author.toProfileJSONFor(user)
+        : null,
     }
   }
   return Comment


### PR DESCRIPTION
## Summary

Article pages on conduit.mate.academy started returning 500 after the avatar-fix deploy rebuilt Next.js ISR caches. Root cause was not the avatar change — it was orphaned `Comment` rows surfacing when `getStaticProps` re-ran.

## Root cause

`Comment.toJson` dereferenced `this.author` unconditionally:

```js
author: await this.author.toProfileJSONFor(user),   // crash if this.author is null
```

The weekly `db_maintenance.sh` cron on the EC2 instance deletes all non-whitelisted Users and Tags but leaves child rows (Comment, Article, UserFollowUser, UserFavoriteArticle, ArticleTag) untouched. Schema has no `ON DELETE CASCADE`, so every Monday run creates a fresh batch of orphans. ISR cached the last good render so this stayed invisible until a rebuild forced re-generation.

Reported article: `/article/the-meowst-useful-article-ever-ul7y7c`. Three articles were affected in total.

## Changes

- **`bin/db_maintenance.sh` (new)** — version-controlled replacement for the on-instance script. Deletes dependents in FK-safe order inside a single transaction. Reads connection params from env with the current values as defaults. Cron line on the instance should be updated to point here once merged.
- **`models/comment.js`** — null-guard `this.author` in `toJson`.
- **`back/ArticlePage.ts`, `api/articles.js`** — filter orphan comments out before serialising, so deleted users do not surface as broken rows in either SSR or the REST API.

## Immediate recovery (already done on prod before this PR)

- `DELETE FROM "Comment" WHERE "authorId" NOT IN (SELECT id FROM "User") AND "articleId" IN (SELECT id FROM "Article")` — 4 rows removed to unblock the three live-broken articles.
- `pm2 restart Conduit` to clear the ISR-cached 500s.
- Site verified HTTP 200 on all three previously-broken slugs.

## Follow-up (separate ticket)

Add `ON DELETE CASCADE` to the FK constraints via a migration so orphan creation is impossible regardless of how users get deleted.